### PR TITLE
Ensure negative height is not given to `whiptail`

### DIFF
--- a/whiptail.py
+++ b/whiptail.py
@@ -57,7 +57,7 @@ class Whiptail(object):
 
     def calc_height(self, msg):
         height_offset = 8 if msg else 7
-        return [str(self.height - height_offset)]
+        return [str(max(0, self.height - height_offset))]
 
     def menu(self, msg='', items=(), prefix=' - '):
         if isinstance(items[0], string_types):


### PR DESCRIPTION
Starting with release [0.52.22](https://github.com/mlichvar/newt/releases/tag/r0-52-22), providing a negative height was leading to the items in a menu not being displayed